### PR TITLE
[INT-9135] - surround properties in quotes to avoid issues caused by dashes

### DIFF
--- a/src/client/sqlCommands.ts
+++ b/src/client/sqlCommands.ts
@@ -7,10 +7,12 @@ const COMMANDS = {
   TO_DATABASE_GRANTS: (databaseName: string) =>
     `SHOW GRANTS ON DATABASE "${databaseName}";`,
   TO_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS TO ROLE "${roleName}";`,
-  TO_USER_GRANTS: (userName: string) => `SHOW GRANTS TO USER "${userName}";`, 
-  TO_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS TO SHARE "${shareName}";`, 
-  OF_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS OF SHARE "${shareName}";`,  
-  OF_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS OF ROLE "${roleName}";`,    
+  TO_USER_GRANTS: (userName: string) => `SHOW GRANTS TO USER "${userName}";`,
+  TO_SHARE_GRANTS: (shareName: string) =>
+    `SHOW GRANTS TO SHARE "${shareName}";`,
+  OF_SHARE_GRANTS: (shareName: string) =>
+    `SHOW GRANTS OF SHARE "${shareName}";`,
+  OF_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS OF ROLE "${roleName}";`,
   FUTURE_SCHEMA_GRANTS: (schemaName: string) =>
     `SHOW FUTURE GRANTS IN SCHEMA "${schemaName}"`,
   FUTURE_DATABASE_GRANTS: (databaseName: string) =>

--- a/src/client/sqlCommands.ts
+++ b/src/client/sqlCommands.ts
@@ -5,16 +5,16 @@ const COMMANDS = {
   GLOBAL_GRANTS: 'SHOW GRANTS;',
   ACCOUNT_GRANTS: 'SHOW GRANTS ON ACCOUNT;',
   TO_DATABASE_GRANTS: (databaseName: string) =>
-    `SHOW GRANTS ON DATABASE ${databaseName};`,
-  TO_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS TO ROLE ${roleName};`,
-  TO_USER_GRANTS: (userName: string) => `SHOW GRANTS TO USER ${userName};`,
-  TO_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS TO SHARE ${shareName};`,
-  OF_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS OF SHARE ${shareName};`,
-  OF_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS OF ROLE ${roleName};`,
+    `SHOW GRANTS ON DATABASE "${databaseName}";`,
+  TO_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS TO ROLE "${roleName}";`,
+  TO_USER_GRANTS: (userName: string) => `SHOW GRANTS TO USER "${userName}";`, 
+  TO_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS TO SHARE "${shareName}";`, 
+  OF_SHARE_GRANTS: (shareName: string) => `SHOW GRANTS OF SHARE "${shareName}";`,  
+  OF_ROLE_GRANTS: (roleName: string) => `SHOW GRANTS OF ROLE "${roleName}";`,    
   FUTURE_SCHEMA_GRANTS: (schemaName: string) =>
-    `SHOW FUTURE GRANTS IN SCHEMA ${schemaName}`,
+    `SHOW FUTURE GRANTS IN SCHEMA "${schemaName}"`,
   FUTURE_DATABASE_GRANTS: (databaseName: string) =>
-    `SHOW FUTURE GRANTS IN DATABASE ${databaseName}`,
+    `SHOW FUTURE GRANTS IN DATABASE "${databaseName}"`,
   ON_OBJECT_GRANTS: ({
     objectType,
     objectName,
@@ -27,7 +27,7 @@ const COMMANDS = {
     // almost everything... ugh.
     objectType: string;
     objectName: string;
-  }) => `SHOW GRANTS ON ${objectType} ${objectName};`,
+  }) => `SHOW GRANTS ON "${objectType}" "${objectName}";`,
   INTEGRATIONS: 'SHOW INTEGRATIONS;',
   MANAGED_ACCOUNTS: 'SHOW MANAGED ACCOUNTS;',
   PIPES: 'SHOW PIPES;',


### PR DESCRIPTION
# Description

The next error with a step was reported:
```
(9:26:10 AM) - [step_failure] - Step "Build User Roles Relationships" failed to complete due to error. (errorCode="PROVIDER_API_ERROR", reason="SQL compilation error:\nsyntax error line 1 at position 22 unexpected '-'.")
```

My hypothesis (confirmed in j1dev) is that this step is being executed with a role that includes a dash `-`. Taking a look at the way snowflake handle dashes `-`, we need to surround the word in quotes to make it work. I've tested this directly in snowflake and also I was able to reproduce it in j1dev. I believe these changes fix the issue and any possible issue in the future caused by dashes in the SQL commands that we are executing to snowflake.

Thank you for contributing to a JupiterOne integration!

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.

## Summary

<!-- Summary here! -->

## Type of change

Please leave any irrelevant options unchecked.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
- [ ] This change requires a documentation update

## Checklist

### General Development Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Integration Development Checklist:

Please leave any irrelevant options unchecked.

- [ ] I have checked for additional permissions required to call any new API
      endpoints, and have documented any additional permissions in
      `jupiterone.md`, where necessary.
- [ ] My changes properly paginate the target service provider's API
- [ ] My changes properly handle rate limiting of the target service provider's
      API
- [ ] My new integration step is instrumented to execute in the correct order
      using `dependsOn`
- [ ] I have referred to the
      [JupiterOne data model](https://github.com/JupiterOne/data-model/tree/main/src/schemas)
      to ensure that any new entities/relationships, and relevant properties,
      match the recommended model for this class of data
- [ ] I have updated the `CHANGELOG.md` file to describe my changes
- [ ] When changes include modifications to existing graph data ingestion, I've
      reviewed all existing managed questions referencing the entities,
      relationships, and their property names, to ensure those questions still
      function with my changes.
